### PR TITLE
Stop auto-starting timers after mode switch (Vibe Kanban)

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -218,6 +218,7 @@ const App = () => {
         if (prev <= 1) {
           playSound(mode, "end");
           const nextMode: Mode = mode === "focus" ? "break" : "focus";
+          setIsRunning(false);
           setMode(nextMode);
           return MODES[nextMode].seconds;
         }


### PR DESCRIPTION
## Summary
- Halt timer auto-start when switching between focus and break modes

## What changed
- Stop the timer as soon as it reaches zero before updating the mode
- Keep the next mode idle until the user manually starts it

## Why
- Prevent overlapping audio by avoiding an immediate auto-start in the new mode after the end sound plays
- Match the intended behavior: mode switches automatically, but the next timer starts manually

## Implementation notes
- The timer interval now calls setIsRunning(false) when the countdown hits zero, then updates the mode and resets the remaining time

This PR was written using [Vibe Kanban](https://vibekanban.com)
