### PR TITLE
fix: configuration window should always be on top of timer window

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,16 @@ const broadcastConfig = (config: AppConfig) => {
   }
 };
 
+const syncConfigWindowAlwaysOnTop = () => {
+  if (!configWindow || configWindow.isDestroyed()) return;
+  const shouldFloat = mainWindow?.isAlwaysOnTop() ?? false;
+  if (shouldFloat) {
+    configWindow.setAlwaysOnTop(true, "modal-panel");
+  } else {
+    configWindow.setAlwaysOnTop(false);
+  }
+};
+
 const loadWindow = (window: BrowserWindow, windowName?: string) => {
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     const url = new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
@@ -138,6 +148,7 @@ const createWindow = () => {
 
 const createConfigWindow = () => {
   if (configWindow && !configWindow.isDestroyed()) {
+    syncConfigWindowAlwaysOnTop();
     configWindow.focus();
     return;
   }
@@ -157,6 +168,7 @@ const createConfigWindow = () => {
   });
 
   loadWindow(configWindow, "config");
+  syncConfigWindowAlwaysOnTop();
 
   configWindow.on("closed", () => {
     configWindow = null;
@@ -170,6 +182,7 @@ ipcMain.handle("always-on-top:get", () => {
 ipcMain.handle("always-on-top:set", (_event, value: boolean) => {
   if (!mainWindow) return false;
   mainWindow.setAlwaysOnTop(Boolean(value), "floating");
+  syncConfigWindowAlwaysOnTop();
   return mainWindow.isAlwaysOnTop();
 });
 


### PR DESCRIPTION
## What changed
- Add a main-process helper to sync the configuration window's always-on-top state with the timer window.
- Apply the sync whenever the config window opens or when the always-on-top toggle changes.

## Why
When the timer is pinned, the settings window can be obscured, forcing users to drag the timer away just to access configuration. This keeps the settings visible and usable.

## Implementation details
- New `syncConfigWindowAlwaysOnTop` checks the timer window's always-on-top state and elevates the config window to `modal-panel` when needed.
- The sync is invoked on config window creation/focus and after toggling always-on-top, so behavior stays consistent.

This PR was written using [Vibe Kanban](https://vibekanban.com)
