### PR TITLE
feat: add focus summary cards to history window

### DIFF
--- a/src/components/HistoryWindow.tsx
+++ b/src/components/HistoryWindow.tsx
@@ -10,7 +10,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useSessionDetailsWindowOpener } from "@/lib/hooks/app-hooks";
-import { useSessionHistory } from "@/lib/hooks/session-hooks";
+import {
+  useSessionHistory,
+  useSessionSummary,
+} from "@/lib/hooks/session-hooks";
 
 const PAGE_SIZE = 10;
 
@@ -36,6 +39,16 @@ const formatDurationMinutes = (
   return String(Math.max(0, minutes));
 };
 
+const formatFocusDuration = (seconds: number) => {
+  const totalMinutes = Math.max(0, Math.round(seconds / 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return {
+    hours: String(hours).padStart(2, "0"),
+    minutes: String(minutes).padStart(2, "0"),
+  };
+};
+
 export const HistoryWindow = () => {
   const [page, setPage] = useState(1);
   const {
@@ -48,6 +61,13 @@ export const HistoryWindow = () => {
     exportSessions,
     importSessions,
   } = useSessionHistory(page, PAGE_SIZE);
+  const {
+    summary,
+    isLoading: isSummaryLoading,
+    error: summaryError,
+    refresh: refreshSummary,
+    isAvailable: isSummaryAvailable,
+  } = useSessionSummary();
   const { openSessionDetailsWindow, isAvailable: isDetailsAvailable } =
     useSessionDetailsWindowOpener();
   const [isTransferring, setIsTransferring] = useState(false);
@@ -68,6 +88,34 @@ export const HistoryWindow = () => {
   const canNext = page < totalPages;
   const showEmpty = !isLoading && data.items.length === 0;
   const canTransfer = isTransferAvailable && !isTransferring;
+  const summarySnapshot = summary ?? {
+    todaySeconds: 0,
+    weekSeconds: 0,
+    monthSeconds: 0,
+  };
+  const summaryCards = [
+    {
+      id: "today",
+      label: "focused today",
+      seconds: summarySnapshot.todaySeconds,
+      gradient: "from-amber-50/90 via-white to-amber-100/70",
+      accent: "bg-amber-400/80",
+    },
+    {
+      id: "week",
+      label: "focused in 7 days",
+      seconds: summarySnapshot.weekSeconds,
+      gradient: "from-sky-50/90 via-white to-sky-100/70",
+      accent: "bg-sky-400/80",
+    },
+    {
+      id: "month",
+      label: "focused last 30 days",
+      seconds: summarySnapshot.monthSeconds,
+      gradient: "from-emerald-50/90 via-white to-emerald-100/70",
+      accent: "bg-emerald-400/80",
+    },
+  ];
 
   const handleExport = async () => {
     setIsTransferring(true);
@@ -98,6 +146,7 @@ export const HistoryWindow = () => {
         return;
       }
       toast.success(`Imported ${result.count ?? 0} sessions.`);
+      void refreshSummary();
       if (page === 1) {
         void refresh();
       } else {
@@ -123,8 +172,13 @@ export const HistoryWindow = () => {
     void runImport();
   };
 
+  const handleRefresh = () => {
+    void refresh();
+    void refreshSummary();
+  };
+
   return (
-    <div className="min-h-screen bg-white px-4 py-5 text-gray-900">
+    <div className="min-h-screen bg-gradient-to-b from-white via-white to-slate-50 px-4 py-6 text-gray-900">
       <header className="space-y-2 pb-4">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
           History
@@ -153,7 +207,50 @@ export const HistoryWindow = () => {
         </div>
       </header>
 
-      <section className="space-y-3">
+      <section className="space-y-4">
+        <div
+          className={`grid grid-cols-3 gap-3 ${isSummaryLoading ? "opacity-70" : ""}`}
+        >
+          {summaryCards.map((card) => {
+            const time = formatFocusDuration(card.seconds);
+            return (
+              <div
+                key={card.id}
+                className={`rounded-2xl border border-slate-200/70 bg-gradient-to-br ${card.gradient} px-4 py-4 shadow-sm`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className={`h-1.5 w-10 rounded-full ${card.accent}`} />
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-500">
+                    Focus
+                  </span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-baseline gap-2 text-slate-900">
+                  <span className="text-2xl font-semibold tabular-nums">
+                    {time.hours}
+                  </span>
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    hrs
+                  </span>
+                  <span className="text-2xl font-semibold tabular-nums">
+                    {time.minutes}
+                  </span>
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    mins
+                  </span>
+                </div>
+                <p className="mt-2 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  {card.label}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+        {!isSummaryAvailable && (
+          <p className="text-xs text-slate-500">
+            Summary stats are unavailable in this window.
+          </p>
+        )}
+        {summaryError && <p className="text-xs text-red-500">{summaryError}</p>}
         <Dialog open={showImportConfirm} onOpenChange={setShowImportConfirm}>
           <DialogContent className="text-left">
             <DialogHeader>
@@ -194,7 +291,7 @@ export const HistoryWindow = () => {
             <Button
               size="sm"
               variant="outline"
-              onClick={refresh}
+              onClick={handleRefresh}
               disabled={isLoading || !isAvailable}
             >
               Refresh

--- a/src/lib/hooks/app-hooks.ts
+++ b/src/lib/hooks/app-hooks.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/pomodoro";
 import type {
   SessionDetail,
+  SessionFocusSummary,
   SessionList,
   SessionTransferResult,
 } from "@/lib/session-types";
@@ -45,6 +46,7 @@ type SessionAPI = {
   }) => Promise<number>;
   list?: (value: { page: number; pageSize: number }) => Promise<SessionList>;
   detail?: (value: { id: number }) => Promise<SessionDetail | null>;
+  summary?: () => Promise<SessionFocusSummary>;
   export?: () => Promise<SessionTransferResult>;
   import?: () => Promise<SessionTransferResult>;
 };

--- a/src/lib/hooks/session-hooks.ts
+++ b/src/lib/hooks/session-hooks.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import type {
   SessionAppUsage,
   SessionDetail,
+  SessionFocusSummary,
   SessionList,
   SessionTransferResult,
 } from "@/lib/session-types";
@@ -118,5 +119,42 @@ export const useSessionDetail = (sessionId?: number | null) => {
     error,
     refresh,
     isAvailable: Boolean(api?.detail),
+  };
+};
+
+export const useSessionSummary = () => {
+  const api = window.electronAPI?.sessions;
+  const [summary, setSummary] = useState<SessionFocusSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!api?.summary) {
+      setError(null);
+      setSummary(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await api.summary();
+      setSummary(result);
+    } catch {
+      setError("Failed to load session summary.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    summary,
+    isLoading,
+    error,
+    refresh,
+    isAvailable: Boolean(api?.summary),
   };
 };

--- a/src/lib/session-types.ts
+++ b/src/lib/session-types.ts
@@ -38,3 +38,9 @@ export type SessionTransferResult = {
   filePath?: string;
   reason?: "canceled" | "invalid-format" | "read-failed" | "write-failed";
 };
+
+export type SessionFocusSummary = {
+  todaySeconds: number;
+  weekSeconds: number;
+  monthSeconds: number;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import Store from "electron-store";
 import {
   addSession,
   closeSessionStore,
+  getSessionFocusSummary,
   getSessionDetail,
   listAllSessions,
   listSessions,
@@ -254,13 +255,13 @@ const createHistoryWindow = () => {
     return;
   }
 
-  const size = { width: 600, height: 520 };
+  const size = { width: 720, height: 680 };
   const position = getOffsetPositionFromMain(size);
   historyWindow = new BrowserWindow({
     width: size.width,
     height: size.height,
-    minWidth: 500,
-    minHeight: 360,
+    minWidth: 720,
+    minHeight: 520,
     ...(position ?? {}),
     resizable: true,
     title: "Session History",
@@ -392,6 +393,10 @@ ipcMain.handle(
 
 ipcMain.handle("sessions:detail", (_event, value: { id: number }) => {
   return getSessionDetail(value.id);
+});
+
+ipcMain.handle("sessions:summary", () => {
+  return getSessionFocusSummary();
 });
 
 const extractSessionRecords = (

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,6 +3,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type {
   SessionDetail,
+  SessionFocusSummary,
   SessionList,
   SessionTransferResult,
 } from "./lib/session-types";
@@ -64,6 +65,8 @@ const sessions = {
       "sessions:detail",
       value,
     ) as Promise<SessionDetail | null>,
+  summary: () =>
+    ipcRenderer.invoke("sessions:summary") as Promise<SessionFocusSummary>,
   export: () =>
     ipcRenderer.invoke("sessions:export") as Promise<SessionTransferResult>,
   import: () =>


### PR DESCRIPTION
Closes #53 

## Summary
- enlarge the history window and add padding so the session table feels airier
- surface today/7-day/30-day focus totals via new session summary data and refreshed styling
- hook the stats cards into the refresh/import flows with gradients and tabular typography for readability

## Testing
- Not run (not requested)