### PR TITLE
feat: add two modes of import: "merge" and "overwrite"

### DIFF
--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,37 @@
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
+
+import { cn } from "@/lib/utils";
+import { CircleIcon } from "lucide-react";
+
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-group"
+      className={cn("grid gap-2 w-full", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-3 aria-invalid:ring-3 group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <RadioPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="group-aria-invalid/radio-group-item:text-destructive text-primary flex size-4 items-center justify-center"
+      >
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-current" />
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/src/lib/hooks/app-hooks.ts
+++ b/src/lib/hooks/app-hooks.ts
@@ -8,6 +8,7 @@ import {
 import type {
   SessionDetail,
   SessionFocusSummary,
+  SessionImportMode,
   SessionList,
   SessionTransferResult,
 } from "@/lib/session-types";
@@ -48,7 +49,9 @@ type SessionAPI = {
   detail?: (value: { id: number }) => Promise<SessionDetail | null>;
   summary?: () => Promise<SessionFocusSummary>;
   export?: () => Promise<SessionTransferResult>;
-  import?: () => Promise<SessionTransferResult>;
+  import?: (value: {
+    mode: SessionImportMode;
+  }) => Promise<SessionTransferResult>;
 };
 
 type HistoryAPI = {

--- a/src/lib/hooks/session-hooks.ts
+++ b/src/lib/hooks/session-hooks.ts
@@ -3,6 +3,7 @@ import type {
   SessionAppUsage,
   SessionDetail,
   SessionFocusSummary,
+  SessionImportMode,
   SessionList,
   SessionTransferResult,
 } from "@/lib/session-types";
@@ -63,10 +64,13 @@ export const useSessionHistory = (page: number, pageSize: number) => {
     return api.export() as Promise<SessionTransferResult>;
   }, [api]);
 
-  const importSessions = useCallback(async () => {
-    if (!api?.import) return null;
-    return api.import() as Promise<SessionTransferResult>;
-  }, [api]);
+  const importSessions = useCallback(
+    async (mode: SessionImportMode) => {
+      if (!api?.import) return null;
+      return api.import({ mode }) as Promise<SessionTransferResult>;
+    },
+    [api],
+  );
 
   return {
     data,

--- a/src/lib/session-types.ts
+++ b/src/lib/session-types.ts
@@ -11,6 +11,8 @@ export type SessionRecord = {
   appUsage?: SessionAppUsage[];
 };
 
+export type SessionImportMode = "merge" | "overwrite";
+
 export type SessionEntry = {
   id: number;
   startedAt: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,6 +4,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import type {
   SessionDetail,
   SessionFocusSummary,
+  SessionImportMode,
   SessionList,
   SessionTransferResult,
 } from "./lib/session-types";
@@ -69,8 +70,11 @@ const sessions = {
     ipcRenderer.invoke("sessions:summary") as Promise<SessionFocusSummary>,
   export: () =>
     ipcRenderer.invoke("sessions:export") as Promise<SessionTransferResult>,
-  import: () =>
-    ipcRenderer.invoke("sessions:import") as Promise<SessionTransferResult>,
+  import: (value: { mode: SessionImportMode }) =>
+    ipcRenderer.invoke(
+      "sessions:import",
+      value,
+    ) as Promise<SessionTransferResult>,
 };
 
 const sessionDetails = {


### PR DESCRIPTION
Closes #55 

## Summary
- Add merge/overwrite selection to the import modal using the shadcn radio group.
- Thread import mode through the renderer, preload bridge, and main IPC handler.
- Implement merge logic that dedupes by started/end timestamps and inserts new sessions in chronological order.

## Why
- The app needed two import behaviors: merge to keep existing sessions while adding new dates, and overwrite to replace everything.

## Implementation details
- Introduced `SessionImportMode` to type the new mode across the API surface.
- `sessions:import` now accepts a mode, defaults to merge, and returns the imported count for both paths.
- Overwrite still uses `replaceSessions`, while merge filters existing session keys before inserting.

This PR was written using [Vibe Kanban](https://vibekanban.com)
