### PR TITLE
feat: add early focus end confirmation flow

### DIFF
--- a/src/lib/hooks/timer-hooks.ts
+++ b/src/lib/hooks/timer-hooks.ts
@@ -302,6 +302,25 @@ export const usePomodoroTimer = (
     setPendingMode(null);
   }, []);
 
+  const endFocusSessionEarly = useCallback(() => {
+    if (mode !== "focus" || isRunning) return false;
+
+    const startedAt = focusStartedAtRef.current;
+    if (!startedAt) return false;
+
+    const endedAt = new Date();
+    onFocusCompleteRef.current?.({
+      startedAt: startedAt.toISOString(),
+      endedAt: endedAt.toISOString(),
+    });
+
+    focusStartedAtRef.current = null;
+    setPendingMode(null);
+    setMode("break");
+    setRemaining(getSecondsForMode("break"));
+    return true;
+  }, [getSecondsForMode, isRunning, mode]);
+
   return {
     mode,
     remaining,
@@ -313,5 +332,6 @@ export const usePomodoroTimer = (
     requestModeSwitch,
     confirmModeSwitch,
     cancelModeSwitch,
+    endFocusSessionEarly,
   };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,11 +193,11 @@ const createWindow = () => {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 360,
-    height: 480,
+    height: 500,
     minWidth: 360,
-    minHeight: 480,
+    minHeight: 500,
     maxWidth: 360,
-    maxHeight: 480,
+    maxHeight: 500,
     resizable: false,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),


### PR DESCRIPTION
Closes #58 

Summary
- add ghost-style "End session" control that appears once a paused focus timer can resume and opens a confirmation dialog
- wire the confirmation dialog to a new `endFocusSessionEarly` hook path that finalizes the focus session and switches into the break timer while ensuring the modal stays open until success
- increase the timer window height/min-height to 500px so the new button doesn’t force extra scrolling and adjust timer alignment to center vertically

Testing
- Not run (not requested)