### PR TITLE
feat: confirm app exit during active focus sessions (Vibe Kanban)

### DIFF
--- a/src/components/TimerWindow.tsx
+++ b/src/components/TimerWindow.tsx
@@ -524,6 +524,18 @@ export const TimerWindow = () => {
   const switchLabel = mode === "focus" ? "Break" : "Focus";
   const canEndSessionEarly = mode === "focus" && !isRunning && showResume;
 
+  useEffect(() => {
+    const focusSessionApi = window.electronAPI?.focusSession;
+    if (!focusSessionApi?.setActive) return;
+
+    const hasActiveSession = mode === "focus" && (isRunning || showResume);
+    focusSessionApi.setActive(hasActiveSession);
+
+    return () => {
+      focusSessionApi.setActive?.(false);
+    };
+  }, [isRunning, mode, showResume]);
+
   const requestEndSessionEarly = useCallback(() => {
     if (!canEndSessionEarly) return;
     setIsEndSessionConfirmOpen(true);

--- a/src/lib/hooks/app-hooks.ts
+++ b/src/lib/hooks/app-hooks.ts
@@ -62,6 +62,10 @@ type SessionDetailsAPI = {
   openWindow?: (sessionId: number) => Promise<boolean>;
 };
 
+type FocusSessionAPI = {
+  setActive?: (value: boolean) => void;
+};
+
 declare global {
   interface Window {
     electronAPI?: {
@@ -69,6 +73,7 @@ declare global {
       activeApp?: ActiveAppAPI;
       config?: ConfigAPI;
       history?: HistoryAPI;
+      focusSession?: FocusSessionAPI;
       sessionDetails?: SessionDetailsAPI;
       sessions?: SessionAPI;
     };

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -52,6 +52,11 @@ const history = {
   openWindow: () => ipcRenderer.invoke("history:open"),
 };
 
+const focusSession = {
+  setActive: (value: boolean) =>
+    ipcRenderer.send("focus-session:set-active", value),
+};
+
 const sessions = {
   add: (value: {
     startedAt: string;
@@ -87,6 +92,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   activeApp,
   config,
   history,
+  focusSession,
   sessionDetails,
   sessions,
 });


### PR DESCRIPTION
Closes #62 

## Summary
This PR adds a close-confirmation flow to prevent accidental app exit while a focus session is still in progress (running or paused).

## What Changed
- Added main-process state tracking for active focus sessions (`hasActiveFocusSession`) and a one-time bypass flag (`isBypassingCloseConfirmation`) to avoid confirmation loops.
- Intercepted `mainWindow` `close` events and showed an Electron native confirmation dialog when a focus session is active.
- Added a new IPC channel (`focus-session:set-active`) in the main process to receive focus-session activity updates.
- Exposed a new preload API (`window.electronAPI.focusSession.setActive`) for renderer-to-main signaling.
- Extended renderer type definitions to include the new `focusSession` API.
- Updated `TimerWindow` to report active focus-session status based on `mode === "focus" && (isRunning || showResume)` and clear it on cleanup.

## Why
The task was to show a confirmation dialog when the user closes the app during an active or paused focus session. Without this guard, users can accidentally quit and lose in-progress session state.

## Important Implementation Details
- The confirmation dialog is only shown for the main timer window and only when focus state is active.
- IPC sender validation uses `BrowserWindow.fromWebContents(event.sender)` to ensure only messages from `mainWindow` can toggle close-guard state.
- The close flow calls `event.preventDefault()` first, then closes only after explicit user confirmation.
- The bypass flag is set before programmatic close to prevent recursive dialog prompts.

This PR was written using [Vibe Kanban](https://vibekanban.com)
