### PR TITLE
chore: configure lefthook hooks and bootstrap prettier baseline

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist
+dist-electron
+node_modules
+release
+public/live2d

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,13 +8,7 @@ import Store from "electron-store";
 const execFileAsync = promisify(execFile);
 
 const getWindowsBinary = app.isPackaged
-  ? path.join(
-      process.resourcesPath,
-      "app.asar.unpacked",
-      "node_modules",
-      "get-windows",
-      "main",
-    )
+  ? path.join(process.resourcesPath, "app.asar.unpacked", "node_modules", "get-windows", "main")
   : path.join(app.getAppPath(), "node_modules", "get-windows", "main");
 
 const getActiveWindowNative = async (): Promise<{
@@ -38,13 +32,13 @@ const getActiveAppInfo = async (): Promise<ActiveAppInfo> => {
     }
     return {
       title: win.title || "",
-      ownerName: win.owner?.name || "",
+      ownerName: win.owner?.name || ""
     };
   } catch (error) {
     return {
       title: "",
       ownerName: "",
-      error: error instanceof Error ? error.message : String(error),
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 };
@@ -57,18 +51,10 @@ import {
   listAllSessions,
   listSessions,
   mergeSessions,
-  replaceSessions,
+  replaceSessions
 } from "./session-store";
-import type {
-  SessionAppUsage,
-  SessionImportMode,
-  SessionRecord,
-} from "../src/lib/session-types";
-import {
-  DEFAULT_BREAK_MINUTES,
-  DEFAULT_FOCUS_MINUTES,
-  clampTimerMinutes,
-} from "../src/lib/pomodoro";
+import type { SessionAppUsage, SessionImportMode, SessionRecord } from "../src/lib/session-types";
+import { DEFAULT_BREAK_MINUTES, DEFAULT_FOCUS_MINUTES, clampTimerMinutes } from "../src/lib/pomodoro";
 
 let mainWindow: BrowserWindow | null = null;
 let configWindow: BrowserWindow | null = null;
@@ -105,11 +91,11 @@ const configStore = new Store<AppConfig>({
     ambientVolumes: {
       fire: 0,
       rain: 0,
-      forest: 0,
+      forest: 0
     },
     focusMinutes: DEFAULT_FOCUS_MINUTES,
-    breakMinutes: DEFAULT_BREAK_MINUTES,
-  },
+    breakMinutes: DEFAULT_BREAK_MINUTES
+  }
 });
 
 const getConfig = (): AppConfig => {
@@ -118,7 +104,7 @@ const getConfig = (): AppConfig => {
     audioLanguage: configStore.get("audioLanguage"),
     ambientVolumes: configStore.get("ambientVolumes"),
     focusMinutes: configStore.get("focusMinutes"),
-    breakMinutes: configStore.get("breakMinutes"),
+    breakMinutes: configStore.get("breakMinutes")
   };
 };
 
@@ -130,10 +116,7 @@ const broadcastConfig = (config: AppConfig) => {
   }
 };
 
-const syncFloatingWindowAlwaysOnTop = (
-  window: BrowserWindow | null,
-  shouldFloat: boolean,
-) => {
+const syncFloatingWindowAlwaysOnTop = (window: BrowserWindow | null, shouldFloat: boolean) => {
   if (!window || window.isDestroyed()) return;
   if (shouldFloat) {
     window.setAlwaysOnTop(true, "modal-panel");
@@ -161,14 +144,9 @@ const getOffsetPositionFromMain = (size: { width: number; height: number }) => {
   return { x, y };
 };
 
-const getDialogParent = () =>
-  historyWindow ?? mainWindow ?? BrowserWindow.getFocusedWindow();
+const getDialogParent = () => historyWindow ?? mainWindow ?? BrowserWindow.getFocusedWindow();
 
-const loadWindow = (
-  window: BrowserWindow,
-  windowName?: string,
-  query: Record<string, string> = {},
-) => {
+const loadWindow = (window: BrowserWindow, windowName?: string, query: Record<string, string> = {}) => {
   const queryParams = { ...query };
   if (windowName) {
     queryParams.window = windowName;
@@ -181,10 +159,7 @@ const loadWindow = (
     window.loadURL(url.toString());
   } else {
     const hasQuery = Object.keys(queryParams).length > 0;
-    window.loadFile(
-      path.join(__dirname, `../dist/index.html`),
-      hasQuery ? { query: queryParams } : undefined,
-    );
+    window.loadFile(path.join(__dirname, `../dist/index.html`), hasQuery ? { query: queryParams } : undefined);
   }
 };
 
@@ -197,8 +172,7 @@ const showCloseConfirmationDialog = async (window: BrowserWindow) => {
     noLink: true,
     title: "Quit Pomo-chan?",
     message: "A focus session is currently running or paused.",
-    detail:
-      "If you quit now, your in-progress focus session will be lost. Do you want to quit anyway?",
+    detail: "If you quit now, your in-progress focus session will be lost. Do you want to quit anyway?"
   });
 
   return response === 1;
@@ -214,8 +188,8 @@ const createWindow = () => {
     maxHeight: 500,
     resizable: false,
     webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-    },
+      preload: path.join(__dirname, "preload.js")
+    }
   });
 
   loadWindow(mainWindow);
@@ -277,8 +251,8 @@ const createConfigWindow = () => {
     resizable: false,
     title: "Settings",
     webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-    },
+      preload: path.join(__dirname, "preload.js")
+    }
   });
 
   loadWindow(configWindow, "config");
@@ -307,8 +281,8 @@ const createHistoryWindow = () => {
     resizable: true,
     title: "Session History",
     webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-    },
+      preload: path.join(__dirname, "preload.js")
+    }
   });
 
   loadWindow(historyWindow, "history");
@@ -326,7 +300,7 @@ const createSessionDetailsWindow = (sessionId: number) => {
   if (sessionDetailsWindow && !sessionDetailsWindow.isDestroyed()) {
     syncAuxWindowsAlwaysOnTop();
     loadWindow(sessionDetailsWindow, "session-details", {
-      sessionId: String(safeId),
+      sessionId: String(safeId)
     });
     sessionDetailsWindow.focus();
     return;
@@ -343,12 +317,12 @@ const createSessionDetailsWindow = (sessionId: number) => {
     resizable: true,
     title: "Session Details",
     webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-    },
+      preload: path.join(__dirname, "preload.js")
+    }
   });
 
   loadWindow(sessionDetailsWindow, "session-details", {
-    sessionId: String(safeId),
+    sessionId: String(safeId)
   });
   syncAuxWindowsAlwaysOnTop();
 
@@ -391,14 +365,8 @@ ipcMain.handle("config:get", () => {
 
 ipcMain.handle("config:set", (_event, value: Partial<AppConfig>) => {
   const current = getConfig();
-  const nextFocusMinutes =
-    value.focusMinutes === undefined
-      ? current.focusMinutes
-      : clampTimerMinutes(value.focusMinutes);
-  const nextBreakMinutes =
-    value.breakMinutes === undefined
-      ? current.breakMinutes
-      : clampTimerMinutes(value.breakMinutes);
+  const nextFocusMinutes = value.focusMinutes === undefined ? current.focusMinutes : clampTimerMinutes(value.focusMinutes);
+  const nextBreakMinutes = value.breakMinutes === undefined ? current.breakMinutes : clampTimerMinutes(value.breakMinutes);
   const nextConfig = {
     ...current,
     ...value,
@@ -406,8 +374,8 @@ ipcMain.handle("config:set", (_event, value: Partial<AppConfig>) => {
     breakMinutes: nextBreakMinutes,
     ambientVolumes: {
       ...current.ambientVolumes,
-      ...(value.ambientVolumes ?? {}),
-    },
+      ...(value.ambientVolumes ?? {})
+    }
   };
   configStore.set(nextConfig);
   broadcastConfig(nextConfig);
@@ -433,12 +401,9 @@ ipcMain.handle("session:add", (_event, value: SessionRecord) => {
   return addSession(value);
 });
 
-ipcMain.handle(
-  "sessions:list",
-  (_event, value: { page: number; pageSize: number }) => {
-    return listSessions(value.page, value.pageSize);
-  },
-);
+ipcMain.handle("sessions:list", (_event, value: { page: number; pageSize: number }) => {
+  return listSessions(value.page, value.pageSize);
+});
 
 ipcMain.handle("sessions:detail", (_event, value: { id: number }) => {
   return getSessionDetail(value.id);
@@ -458,9 +423,7 @@ ipcMain.handle("sessions:clear", () => {
   }
 });
 
-const extractSessionRecords = (
-  payload: unknown,
-): { records: SessionRecord[]; recognized: boolean; sourceCount: number } => {
+const extractSessionRecords = (payload: unknown): { records: SessionRecord[]; recognized: boolean; sourceCount: number } => {
   if (!payload || typeof payload !== "object") {
     return { records: [], recognized: false, sourceCount: 0 };
   }
@@ -479,15 +442,11 @@ const extractSessionRecords = (
         focusSeconds?: unknown;
         appUsage?: unknown;
       };
-      if (
-        typeof candidate.startedAt !== "string" ||
-        typeof candidate.endedAt !== "string"
-      ) {
+      if (typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string") {
         return null;
       }
       const focusSeconds =
-        typeof candidate.focusSeconds === "number" &&
-        Number.isFinite(candidate.focusSeconds)
+        typeof candidate.focusSeconds === "number" && Number.isFinite(candidate.focusSeconds)
           ? candidate.focusSeconds
           : undefined;
       const appUsage = Array.isArray(candidate.appUsage)
@@ -509,7 +468,7 @@ const extractSessionRecords = (
               return {
                 appName: usageCandidate.appName,
                 startedAt: usageCandidate.startedAt,
-                endedAt: usageCandidate.endedAt,
+                endedAt: usageCandidate.endedAt
               } satisfies SessionAppUsage;
             })
             .filter(Boolean) as SessionAppUsage[])
@@ -518,7 +477,7 @@ const extractSessionRecords = (
         startedAt: candidate.startedAt,
         endedAt: candidate.endedAt,
         focusSeconds,
-        appUsage,
+        appUsage
       };
     })
     .filter(Boolean) as SessionRecord[];
@@ -526,7 +485,7 @@ const extractSessionRecords = (
   return {
     records,
     recognized: true,
-    sourceCount: root.sessions.length,
+    sourceCount: root.sessions.length
   };
 };
 
@@ -535,17 +494,12 @@ ipcMain.handle("sessions:export", async () => {
   const now = new Date();
   const padded = (value: number) => String(value).padStart(2, "0");
   const timestamp = `${now.getFullYear()}${padded(now.getMonth() + 1)}${padded(
-    now.getDate(),
-  )}-${padded(now.getHours())}${padded(now.getMinutes())}${padded(
-    now.getSeconds(),
-  )}`;
+    now.getDate()
+  )}-${padded(now.getHours())}${padded(now.getMinutes())}${padded(now.getSeconds())}`;
   const { canceled, filePath } = await dialog.showSaveDialog(parent, {
     title: "Export sessions",
-    defaultPath: path.join(
-      app.getPath("downloads"),
-      `pomo-chan-sessions-${timestamp}.json`,
-    ),
-    filters: [{ name: "JSON", extensions: ["json"] }],
+    defaultPath: path.join(app.getPath("downloads"), `pomo-chan-sessions-${timestamp}.json`),
+    filters: [{ name: "JSON", extensions: ["json"] }]
   });
   if (canceled || !filePath) {
     return { ok: false, reason: "canceled" } as const;
@@ -555,7 +509,7 @@ ipcMain.handle("sessions:export", async () => {
   const payload = {
     version: 2,
     exportedAt: new Date().toISOString(),
-    sessions,
+    sessions
   };
 
   try {
@@ -567,56 +521,53 @@ ipcMain.handle("sessions:export", async () => {
   }
 });
 
-ipcMain.handle(
-  "sessions:import",
-  async (_event, options?: { mode?: SessionImportMode }) => {
-    const parent = getDialogParent();
-    const { canceled, filePaths } = await dialog.showOpenDialog(parent, {
-      title: "Import sessions",
-      filters: [{ name: "JSON", extensions: ["json"] }],
-      properties: ["openFile"],
-    });
-    if (canceled || filePaths.length === 0) {
-      return { ok: false, reason: "canceled" } as const;
-    }
+ipcMain.handle("sessions:import", async (_event, options?: { mode?: SessionImportMode }) => {
+  const parent = getDialogParent();
+  const { canceled, filePaths } = await dialog.showOpenDialog(parent, {
+    title: "Import sessions",
+    filters: [{ name: "JSON", extensions: ["json"] }],
+    properties: ["openFile"]
+  });
+  if (canceled || filePaths.length === 0) {
+    return { ok: false, reason: "canceled" } as const;
+  }
 
-    let raw = "";
-    try {
-      raw = await fs.readFile(filePaths[0], "utf8");
-    } catch (error) {
-      console.error("Failed to read sessions file", error);
-      return { ok: false, reason: "read-failed" } as const;
-    }
+  let raw = "";
+  try {
+    raw = await fs.readFile(filePaths[0], "utf8");
+  } catch (error) {
+    console.error("Failed to read sessions file", error);
+    return { ok: false, reason: "read-failed" } as const;
+  }
 
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch (error) {
-      console.error("Failed to parse sessions file", error);
-      return { ok: false, reason: "invalid-format" } as const;
-    }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.error("Failed to parse sessions file", error);
+    return { ok: false, reason: "invalid-format" } as const;
+  }
 
-    const { records, recognized, sourceCount } = extractSessionRecords(parsed);
-    if (!recognized || (sourceCount > 0 && records.length === 0)) {
-      return { ok: false, reason: "invalid-format" } as const;
-    }
+  const { records, recognized, sourceCount } = extractSessionRecords(parsed);
+  if (!recognized || (sourceCount > 0 && records.length === 0)) {
+    return { ok: false, reason: "invalid-format" } as const;
+  }
 
-    const mode = options?.mode === "overwrite" ? "overwrite" : "merge";
-    try {
-      let count = 0;
-      if (mode === "overwrite") {
-        replaceSessions(records);
-        count = records.length;
-      } else {
-        count = mergeSessions(records);
-      }
-      return { ok: true, count } as const;
-    } catch (error) {
-      console.error("Failed to import sessions", error);
-      return { ok: false, reason: "write-failed" } as const;
+  const mode = options?.mode === "overwrite" ? "overwrite" : "merge";
+  try {
+    let count = 0;
+    if (mode === "overwrite") {
+      replaceSessions(records);
+      count = records.length;
+    } else {
+      count = mergeSessions(records);
     }
-  },
-);
+    return { ok: true, count } as const;
+  } catch (error) {
+    console.error("Failed to import sessions", error);
+    return { ok: false, reason: "write-failed" } as const;
+  }
+});
 
 app.on("ready", createWindow);
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,7 +4,7 @@ import type {
   SessionFocusSummary,
   SessionImportMode,
   SessionList,
-  SessionTransferResult,
+  SessionTransferResult
 } from "../src/lib/session-types";
 
 type AudioLanguage = "en" | "jp";
@@ -24,7 +24,7 @@ type AppConfig = {
 
 const alwaysOnTop = {
   get: () => ipcRenderer.invoke("always-on-top:get"),
-  set: (value: boolean) => ipcRenderer.invoke("always-on-top:set", value),
+  set: (value: boolean) => ipcRenderer.invoke("always-on-top:set", value)
 };
 
 const activeApp = {
@@ -33,13 +33,12 @@ const activeApp = {
       title: string;
       ownerName: string;
     }>,
-  debug: () => ipcRenderer.invoke("active-app:debug"),
+  debug: () => ipcRenderer.invoke("active-app:debug")
 };
 
 const config = {
   get: () => ipcRenderer.invoke("config:get") as Promise<AppConfig>,
-  set: (value: Partial<AppConfig>) =>
-    ipcRenderer.invoke("config:set", value) as Promise<AppConfig>,
+  set: (value: Partial<AppConfig>) => ipcRenderer.invoke("config:set", value) as Promise<AppConfig>,
   onChange: (callback: (value: AppConfig) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, value: AppConfig) => {
       callback(value);
@@ -47,48 +46,30 @@ const config = {
     ipcRenderer.on("config:changed", handler);
     return () => ipcRenderer.off("config:changed", handler);
   },
-  openWindow: () => ipcRenderer.invoke("config:open"),
+  openWindow: () => ipcRenderer.invoke("config:open")
 };
 
 const history = {
-  openWindow: () => ipcRenderer.invoke("history:open"),
+  openWindow: () => ipcRenderer.invoke("history:open")
 };
 
 const focusSession = {
-  setActive: (value: boolean) =>
-    ipcRenderer.send("focus-session:set-active", value),
+  setActive: (value: boolean) => ipcRenderer.send("focus-session:set-active", value)
 };
 
 const sessions = {
-  add: (value: {
-    startedAt: string;
-    endedAt: string;
-    focusSeconds?: number | null;
-    appUsage?: SessionDetail["appUsage"];
-  }) => ipcRenderer.invoke("session:add", value) as Promise<number>,
-  list: (value: { page: number; pageSize: number }) =>
-    ipcRenderer.invoke("sessions:list", value) as Promise<SessionList>,
-  detail: (value: { id: number }) =>
-    ipcRenderer.invoke(
-      "sessions:detail",
-      value,
-    ) as Promise<SessionDetail | null>,
-  summary: () =>
-    ipcRenderer.invoke("sessions:summary") as Promise<SessionFocusSummary>,
-  export: () =>
-    ipcRenderer.invoke("sessions:export") as Promise<SessionTransferResult>,
-  import: (value: { mode: SessionImportMode }) =>
-    ipcRenderer.invoke(
-      "sessions:import",
-      value,
-    ) as Promise<SessionTransferResult>,
-  clear: () =>
-    ipcRenderer.invoke("sessions:clear") as Promise<SessionTransferResult>,
+  add: (value: { startedAt: string; endedAt: string; focusSeconds?: number | null; appUsage?: SessionDetail["appUsage"] }) =>
+    ipcRenderer.invoke("session:add", value) as Promise<number>,
+  list: (value: { page: number; pageSize: number }) => ipcRenderer.invoke("sessions:list", value) as Promise<SessionList>,
+  detail: (value: { id: number }) => ipcRenderer.invoke("sessions:detail", value) as Promise<SessionDetail | null>,
+  summary: () => ipcRenderer.invoke("sessions:summary") as Promise<SessionFocusSummary>,
+  export: () => ipcRenderer.invoke("sessions:export") as Promise<SessionTransferResult>,
+  import: (value: { mode: SessionImportMode }) => ipcRenderer.invoke("sessions:import", value) as Promise<SessionTransferResult>,
+  clear: () => ipcRenderer.invoke("sessions:clear") as Promise<SessionTransferResult>
 };
 
 const sessionDetails = {
-  openWindow: (sessionId: number) =>
-    ipcRenderer.invoke("session-details:open", sessionId),
+  openWindow: (sessionId: number) => ipcRenderer.invoke("session-details:open", sessionId)
 };
 
 contextBridge.exposeInMainWorld("electronAPI", {
@@ -98,5 +79,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
   history,
   focusSession,
   sessionDetails,
-  sessions,
+  sessions
 });

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -5,12 +5,12 @@ const { FlatCompat } = require("@eslint/eslintrc");
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
+  recommendedConfig: js.configs.recommended
 });
 
 module.exports = [
   {
-    ignores: ["public/**", ".vite/**", "dist/**"],
+    ignores: ["public/**", ".vite/**", "dist/**"]
   },
   ...compat.extends(
     "eslint:recommended",
@@ -18,37 +18,37 @@ module.exports = [
     "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
     "plugin:import/electron",
-    "plugin:import/typescript",
+    "plugin:import/typescript"
   ),
   {
     languageOptions: {
       parser: require("@typescript-eslint/parser"),
       parserOptions: {
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: __dirname
       },
       ecmaVersion: "latest",
       sourceType: "module",
       globals: {
         ...globals.browser,
-        ...globals.node,
-      },
+        ...globals.node
+      }
     },
     settings: {
       "import/resolver": {
         typescript: {
-          project: [path.join(__dirname, "tsconfig.json")],
+          project: [path.join(__dirname, "tsconfig.json")]
         },
         alias: {
           map: [["@", path.join(__dirname, "src")]],
-          extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
-        },
-      },
-    },
+          extensions: [".ts", ".tsx", ".js", ".jsx", ".json"]
+        }
+      }
+    }
   },
   {
     files: ["eslint.config.cjs"],
     rules: {
-      "@typescript-eslint/no-require-imports": "off",
-    },
-  },
+      "@typescript-eslint/no-require-imports": "off"
+    }
+  }
 ];

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,11 +2,18 @@ pre-commit:
   parallel: true
   commands:
     prettier:
-      files: git diff --name-only --cached --diff-filter=ACMR -- src "*.json"
-      run: npx prettier --write --ignore-unknown {files}
+      run: npx prettier --write --ignore-unknown {staged_files}
       stage_fixed: true
 
 pre-push:
+  parallel: true
   commands:
+    lint:
+      run: npm run lint
     typecheck:
       run: npm run typecheck
+
+post-checkout:
+  commands:
+    install-deps:
+      run: "[ -f package.json ] && npm install || true"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package": "npm run build && electron-builder --dir",
     "make": "npm run build && electron-builder",
     "lint": "eslint .",
-    "format": "prettier --write \"src/**/*\" \"*.json\"",
+    "format": "prettier --write --ignore-unknown .",
     "typecheck": "tsc --noEmit",
     "prepare": "lefthook install"
   },

--- a/src/components/SessionDetailWindow.tsx
+++ b/src/components/SessionDetailWindow.tsx
@@ -47,8 +47,7 @@ const getSegmentSeconds = (segment: SessionAppUsage) => {
 
 export const SessionDetailWindow = () => {
   const sessionId = useMemo(() => getSessionIdFromQuery(), []);
-  const { data, isLoading, error, refresh, isAvailable } =
-    useSessionDetail(sessionId);
+  const { data, isLoading, error, refresh, isAvailable } = useSessionDetail(sessionId);
 
   const segments = data?.appUsage ?? [];
   const totals = useMemo(() => {
@@ -74,27 +73,16 @@ export const SessionDetailWindow = () => {
   return (
     <div className="min-h-screen bg-white px-4 py-5 text-gray-900">
       <header className="space-y-2 pb-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
-          Session details
-        </p>
-        <h1 className="text-2xl font-semibold">
-          {sessionId ? `Session ${sessionId}` : "Session"}
-        </h1>
-        <p className="text-sm text-gray-500">
-          Focus usage is captured only while the timer runs.
-        </p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">Session details</p>
+        <h1 className="text-2xl font-semibold">{sessionId ? `Session ${sessionId}` : "Session"}</h1>
+        <p className="text-sm text-gray-500">Focus usage is captured only while the timer runs.</p>
         <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
           <span>Started at {data ? formatTimestamp(data.startedAt) : "-"}</span>
           <span>Ended at {data ? formatTimestamp(data.endedAt) : "-"}</span>
           <span>Total focus {formatDuration(totalSeconds ?? Number.NaN)}</span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={refresh}
-            disabled={!isAvailable || isLoading}
-          >
+          <Button size="sm" variant="outline" onClick={refresh} disabled={!isAvailable || isLoading}>
             Refresh
           </Button>
         </div>
@@ -102,52 +90,30 @@ export const SessionDetailWindow = () => {
 
       <section className="space-y-4">
         {error && <div className="text-sm text-red-500">{error}</div>}
-        {isLoading && (
-          <div className="text-sm text-gray-500">Loading session data...</div>
-        )}
-        {!isAvailable && (
-          <div className="text-sm text-gray-500">
-            Session details are unavailable in this window.
-          </div>
-        )}
-        {!error && !isLoading && isAvailable && !data && (
-          <div className="text-sm text-gray-500">Session not found.</div>
-        )}
+        {isLoading && <div className="text-sm text-gray-500">Loading session data...</div>}
+        {!isAvailable && <div className="text-sm text-gray-500">Session details are unavailable in this window.</div>}
+        {!error && !isLoading && isAvailable && !data && <div className="text-sm text-gray-500">Session not found.</div>}
 
         <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
           <div className="space-y-1">
-            <h2 className="text-sm font-semibold text-gray-900">
-              Application usage summary
-            </h2>
-            <p className="text-xs text-gray-500">
-              Distribution of focus time by application.
-            </p>
+            <h2 className="text-sm font-semibold text-gray-900">Application usage summary</h2>
+            <p className="text-xs text-gray-500">Distribution of focus time by application.</p>
           </div>
           <div className="mt-4 space-y-3">
-            {totals.length === 0 && (
-              <p className="text-sm text-gray-500">No usage data recorded.</p>
-            )}
+            {totals.length === 0 && <p className="text-sm text-gray-500">No usage data recorded.</p>}
             {totals.map((entry) => {
               const total = totalSeconds ?? 0;
               const percent = total > 0 ? (entry.seconds / total) * 100 : 0;
               return (
                 <div key={entry.appName} className="space-y-1">
                   <div className="flex items-center justify-between gap-2 text-xs text-gray-600">
-                    <span
-                      className="truncate font-semibold text-gray-900"
-                      title={entry.appName}
-                    >
+                    <span className="truncate font-semibold text-gray-900" title={entry.appName}>
                       {entry.appName}
                     </span>
-                    <span className="tabular-nums text-gray-500">
-                      {formatDuration(entry.seconds)}
-                    </span>
+                    <span className="tabular-nums text-gray-500">{formatDuration(entry.seconds)}</span>
                   </div>
                   <div className="h-2 w-full rounded-full bg-gray-100">
-                    <div
-                      className="h-2 rounded-full bg-gray-900"
-                      style={{ width: `${percent}%` }}
-                    />
+                    <div className="h-2 rounded-full bg-gray-900" style={{ width: `${percent}%` }} />
                   </div>
                 </div>
               );
@@ -157,32 +123,20 @@ export const SessionDetailWindow = () => {
 
         <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
           <div className="space-y-1">
-            <h2 className="text-sm font-semibold text-gray-900">
-              Detailed timeline
-            </h2>
-            <p className="text-xs text-gray-500">
-              Each row represents a continuous active app interval.
-            </p>
+            <h2 className="text-sm font-semibold text-gray-900">Detailed timeline</h2>
+            <p className="text-xs text-gray-500">Each row represents a continuous active app interval.</p>
           </div>
           <div className="mt-4 divide-y divide-gray-200 text-sm">
-            {segments.length === 0 && (
-              <div className="py-3 text-gray-500">
-                No intervals recorded for this session.
-              </div>
-            )}
+            {segments.length === 0 && <div className="py-3 text-gray-500">No intervals recorded for this session.</div>}
             {segments.map((segment, index) => (
               <div
                 key={`${segment.startedAt}-${segment.endedAt}-${index}`}
                 className="flex items-center justify-between gap-2 py-2"
               >
                 <span className="shrink-0 font-medium text-gray-900">
-                  {formatTime(segment.startedAt)} -{" "}
-                  {formatTime(segment.endedAt)}
+                  {formatTime(segment.startedAt)} - {formatTime(segment.endedAt)}
                 </span>
-                <span
-                  className="min-w-0 flex-1 truncate text-right text-gray-600"
-                  title={segment.appName}
-                >
+                <span className="min-w-0 flex-1 truncate text-right text-gray-600" title={segment.appName}>
                   {segment.appName}
                 </span>
               </div>

--- a/src/components/TimerWindow.tsx
+++ b/src/components/TimerWindow.tsx
@@ -2,14 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import * as PIXI from "pixi.js";
 import { Live2DModel } from "pixi-live2d-display";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { History, Settings2 } from "lucide-react";
 import { MODES, formatTime, type Mode } from "@/lib/pomodoro";
@@ -19,7 +12,7 @@ import {
   useAlwaysOnTop,
   useAppConfig,
   useConfigWindowOpener,
-  useHistoryWindowOpener,
+  useHistoryWindowOpener
 } from "@/lib/hooks/app-hooks";
 import { usePomodoroTimer } from "@/lib/hooks/timer-hooks";
 import { useSessionRecorder } from "@/lib/hooks/session-hooks";
@@ -72,12 +65,7 @@ type Live2DStageProps = {
   voiceAudioSignal?: VoiceAudioSignal;
 };
 
-const Live2DStage = ({
-  activeWindowTitle,
-  activeAppOwner,
-  showActiveApp,
-  voiceAudioSignal,
-}: Live2DStageProps) => {
+const Live2DStage = ({ activeWindowTitle, activeAppOwner, showActiveApp, voiceAudioSignal }: Live2DStageProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const live2dModelRef = useRef<Live2DModel | null>(null);
@@ -86,15 +74,8 @@ const Live2DStage = ({
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const analyserBufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
-  const audioSourcesRef = useRef(
-    new Map<HTMLAudioElement, MediaElementAudioSourceNode>(),
-  );
-  const audioListenersRef = useRef(
-    new Map<
-      HTMLAudioElement,
-      { onPlay: () => void; onPause: () => void; onEnded: () => void }
-    >(),
-  );
+  const audioSourcesRef = useRef(new Map<HTMLAudioElement, MediaElementAudioSourceNode>());
+  const audioListenersRef = useRef(new Map<HTMLAudioElement, { onPlay: () => void; onPause: () => void; onEnded: () => void }>());
   const activeAudioRef = useRef<HTMLAudioElement | null>(null);
   const internalModelRef = useRef<InternalModelWithEvents | null>(null);
 
@@ -102,9 +83,7 @@ const Live2DStage = ({
   // read its volume in real time and drive the mouth parameter while it plays.
   const setupVoiceAudio = useCallback((audio: HTMLAudioElement) => {
     const AudioContextCtor =
-      window.AudioContext ||
-      (window as typeof window & { webkitAudioContext?: typeof AudioContext })
-        .webkitAudioContext;
+      window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
     if (!AudioContextCtor) return;
 
     if (!audioContextRef.current) {
@@ -118,9 +97,7 @@ const Live2DStage = ({
       analyser.smoothingTimeConstant = 0.6;
       analyser.connect(audioContext.destination);
       analyserRef.current = analyser;
-      analyserBufferRef.current = new Uint8Array(
-        new ArrayBuffer(analyser.fftSize),
-      );
+      analyserBufferRef.current = new Uint8Array(new ArrayBuffer(analyser.fftSize));
     }
     const analyser = analyserRef.current;
     if (!analyser) return;
@@ -154,7 +131,7 @@ const Live2DStage = ({
       audioListenersRef.current.set(audio, {
         onPlay: handlePlay,
         onPause: handlePause,
-        onEnded: handleEnded,
+        onEnded: handleEnded
       });
     }
 
@@ -176,7 +153,7 @@ const Live2DStage = ({
       backgroundAlpha: 0,
       antialias: true,
       autoDensity: true,
-      resizeTo: container,
+      resizeTo: container
     });
 
     const canvas = app.view as HTMLCanvasElement;
@@ -191,9 +168,7 @@ const Live2DStage = ({
     // value into the model's mouth-open parameter each frame.
     const updateLipSync = () => {
       const modelInstance = live2dModelRef.current;
-      const coreModel = modelInstance?.internalModel?.coreModel as
-        | Live2DCoreModel
-        | undefined;
+      const coreModel = modelInstance?.internalModel?.coreModel as Live2DCoreModel | undefined;
       const ids = lipSyncIdsRef.current;
       if (!coreModel || ids.length === 0) return;
 
@@ -201,12 +176,7 @@ const Live2DStage = ({
       const activeAudio = activeAudioRef.current;
       let target = 0;
 
-      if (
-        activeAudio &&
-        analyser &&
-        !activeAudio.paused &&
-        !activeAudio.ended
-      ) {
+      if (activeAudio && analyser && !activeAudio.paused && !activeAudio.ended) {
         const buffer = analyserBufferRef.current;
         if (buffer) {
           analyser.getByteTimeDomainData(buffer);
@@ -248,9 +218,7 @@ const Live2DStage = ({
       if (!width || !height || !modelBaseSize.width || !modelBaseSize.height) {
         return;
       }
-      const scale =
-        Math.min(width / modelBaseSize.width, height / modelBaseSize.height) *
-        LIVE2D_ZOOM;
+      const scale = Math.min(width / modelBaseSize.width, height / modelBaseSize.height) * LIVE2D_ZOOM;
       model.scale.set(scale);
       model.pivot.set(modelBaseSize.width / 2, modelBaseSize.height / 2);
       model.position.set(width / 2, height / 2 + height * LIVE2D_Y_OFFSET);
@@ -261,7 +229,7 @@ const Live2DStage = ({
         model = await Live2DModel.from(LIVE2D_MODEL_URL, {
           autoInteract: true,
           // Disable built-in idle motions so the model only moves when we drive it.
-          idleMotionGroup: "__none__",
+          idleMotionGroup: "__none__"
         });
         if (destroyed) {
           model.destroy();
@@ -276,8 +244,7 @@ const Live2DStage = ({
         app.renderer.on("resize", fitModel);
         live2dModelRef.current = model;
         model.once("ready", () => {
-          const internalModel =
-            model?.internalModel as unknown as InternalModelWithEvents;
+          const internalModel = model?.internalModel as unknown as InternalModelWithEvents;
           if (internalModel?.on) {
             internalModel.on("afterMotionUpdate", updateLipSync);
             internalModelRef.current = internalModel;
@@ -300,15 +267,10 @@ const Live2DStage = ({
             };
             const groups = Array.isArray(data?.Groups) ? data.Groups : [];
             const lipSyncGroup = groups.find(
-              (group) =>
-                group?.Target === "Parameter" &&
-                group?.Name === "LipSync" &&
-                Array.isArray(group?.Ids),
+              (group) => group?.Target === "Parameter" && group?.Name === "LipSync" && Array.isArray(group?.Ids)
             );
             if (lipSyncGroup?.Ids?.length) {
-              lipSyncIdsRef.current = lipSyncGroup.Ids.filter(
-                (id) => typeof id === "string",
-              );
+              lipSyncIdsRef.current = lipSyncGroup.Ids.filter((id) => typeof id === "string");
             }
           } catch (error) {
             console.warn("Failed to load lip sync parameters", error);
@@ -362,24 +324,14 @@ const Live2DStage = ({
   return (
     <div className="relative flex h-65 w-full max-w-3xl items-center justify-center overflow-hidden rounded-2xl bg-gray-200 sm:h-75">
       {/* Live2D canvas mounts into this container. */}
-      {!isLoaded && (
-        <span className="pointer-events-none relative z-10 text-sm font-medium text-gray-500">
-          Loading model...
-        </span>
-      )}
+      {!isLoaded && <span className="pointer-events-none relative z-10 text-sm font-medium text-gray-500">Loading model...</span>}
       {showActiveApp && (
         <div className="absolute bottom-3 left-3 z-10 flex max-w-[70%] flex-col gap-0.5 rounded-lg bg-white/90 px-3 py-1.5 text-[0.65rem] font-semibold text-gray-600 shadow-sm backdrop-blur">
           <div className="flex items-center gap-2">
             <span className="uppercase tracking-[0.2em]">Active app</span>
-            <span className="truncate text-[0.7rem] font-medium text-gray-900">
-              {activeAppOwner || "Unknown"}
-            </span>
+            <span className="truncate text-[0.7rem] font-medium text-gray-900">{activeAppOwner || "Unknown"}</span>
           </div>
-          {activeWindowTitle && (
-            <span className="truncate text-[0.6rem] text-gray-500">
-              {activeWindowTitle}
-            </span>
-          )}
+          {activeWindowTitle && <span className="truncate text-[0.6rem] text-gray-500">{activeWindowTitle}</span>}
         </div>
       )}
       <div ref={containerRef} className="absolute inset-0" />
@@ -389,24 +341,18 @@ const Live2DStage = ({
 
 export const TimerWindow = () => {
   const { config } = useAppConfig();
-  const { openConfigWindow, isAvailable: isConfigAvailable } =
-    useConfigWindowOpener();
-  const { openHistoryWindow, isAvailable: isHistoryAvailable } =
-    useHistoryWindowOpener();
+  const { openConfigWindow, isAvailable: isConfigAvailable } = useConfigWindowOpener();
+  const { openHistoryWindow, isAvailable: isHistoryAvailable } = useHistoryWindowOpener();
   const { addSession } = useSessionRecorder();
-  const {
-    value: isAlwaysOnTop,
-    setValue: setAlwaysOnTop,
-    isAvailable: isAlwaysOnTopAvailable,
-  } = useAlwaysOnTop();
+  const { value: isAlwaysOnTop, setValue: setAlwaysOnTop, isAvailable: isAlwaysOnTopAvailable } = useAlwaysOnTop();
   const {
     title: activeWindowTitle,
     ownerName: activeAppOwner,
-    isAvailable: isActiveAppAvailable,
+    isAvailable: isActiveAppAvailable
   } = useActiveWindowInfo(ACTIVE_APP_POLL_INTERVAL_MS);
   const [voiceAudioSignal, setVoiceAudioSignal] = useState<VoiceAudioSignal>({
     audio: null,
-    token: 0,
+    token: 0
   });
   const [isEndSessionConfirmOpen, setIsEndSessionConfirmOpen] = useState(false);
   const usageSegmentsRef = useRef<SessionAppUsage[]>([]);
@@ -429,7 +375,7 @@ export const TimerWindow = () => {
     usageSegmentsRef.current.push({
       appName: active.appName,
       startedAt: active.startedAt,
-      endedAt: endedAt.toISOString(),
+      endedAt: endedAt.toISOString()
     });
   }, []);
 
@@ -442,10 +388,10 @@ export const TimerWindow = () => {
       }
       activeSegmentRef.current = {
         appName,
-        startedAt: at.toISOString(),
+        startedAt: at.toISOString()
       };
     },
-    [closeActiveSegment],
+    [closeActiveSegment]
   );
 
   const discardSegments = useCallback(() => {
@@ -460,7 +406,7 @@ export const TimerWindow = () => {
       discardSegments();
       return segments;
     },
-    [closeActiveSegment, discardSegments],
+    [closeActiveSegment, discardSegments]
   );
 
   const handleVoiceAudioPlay = useCallback((audio: HTMLAudioElement) => {
@@ -470,22 +416,16 @@ export const TimerWindow = () => {
     (session: { startedAt: string; endedAt: string }) => {
       const segments = finalizeSegments(session.endedAt);
       const derivedFocusSeconds = calculateFocusSeconds(segments);
-      const fallbackFocusSeconds = Math.max(
-        0,
-        Math.round(
-          (Date.parse(session.endedAt) - Date.parse(session.startedAt)) / 1000,
-        ),
-      );
-      const focusSeconds =
-        segments.length > 0 ? derivedFocusSeconds : fallbackFocusSeconds;
+      const fallbackFocusSeconds = Math.max(0, Math.round((Date.parse(session.endedAt) - Date.parse(session.startedAt)) / 1000));
+      const focusSeconds = segments.length > 0 ? derivedFocusSeconds : fallbackFocusSeconds;
       void addSession({
         startedAt: session.startedAt,
         endedAt: session.endedAt,
         focusSeconds,
-        appUsage: segments,
+        appUsage: segments
       });
     },
-    [addSession, finalizeSegments],
+    [addSession, finalizeSegments]
   );
   const {
     mode,
@@ -498,17 +438,15 @@ export const TimerWindow = () => {
     requestModeSwitch,
     confirmModeSwitch,
     cancelModeSwitch,
-    endFocusSessionEarly,
+    endFocusSessionEarly
   } = usePomodoroTimer(config, {
     onVoiceAudioPlay: handleVoiceAudioPlay,
-    onFocusComplete: handleFocusComplete,
+    onFocusComplete: handleFocusComplete
   });
 
   const activeAppLabel = isActiveAppAvailable
     ? normalizeAppName(
-        activeAppOwner && activeWindowTitle
-          ? `${activeAppOwner}: ${activeWindowTitle}`
-          : activeAppOwner || "Unknown",
+        activeAppOwner && activeWindowTitle ? `${activeAppOwner}: ${activeWindowTitle}` : activeAppOwner || "Unknown"
       )
     : "Unavailable";
 
@@ -613,23 +551,14 @@ export const TimerWindow = () => {
 
       <div className="flex flex-1 flex-col justify-center">
         <section className="text-center">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
-            {MODES[mode].label} Timer
-          </h2>
-          <h1
-            className="mt-2 text-[clamp(2.4rem,6.5vw,4rem)] font-semibold leading-none tabular-nums"
-            aria-live="polite"
-          >
+          <h2 className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">{MODES[mode].label} Timer</h2>
+          <h1 className="mt-2 text-[clamp(2.4rem,6.5vw,4rem)] font-semibold leading-none tabular-nums" aria-live="polite">
             {formattedTime}
           </h1>
         </section>
 
         <section className="flex items-center justify-center gap-3 pb-2 pt-4">
-          <Button
-            className="rounded-full px-6 py-2.5 text-sm font-semibold"
-            type="button"
-            onClick={toggleRunning}
-          >
+          <Button className="rounded-full px-6 py-2.5 text-sm font-semibold" type="button" onClick={toggleRunning}>
             {primaryLabel}
           </Button>
           <Button
@@ -663,23 +592,14 @@ export const TimerWindow = () => {
       >
         <DialogContent className="text-left">
           <DialogHeader>
-            <DialogTitle>
-              Switch to {pendingMode ? MODES[pendingMode].label : switchLabel}{" "}
-              timer?
-            </DialogTitle>
-            <DialogDescription>
-              Your current timer progress will be lost if you switch modes.
-            </DialogDescription>
+            <DialogTitle>Switch to {pendingMode ? MODES[pendingMode].label : switchLabel} timer?</DialogTitle>
+            <DialogDescription>Your current timer progress will be lost if you switch modes.</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" type="button" onClick={cancelModeSwitch}>
               Keep {MODES[mode].label}
             </Button>
-            <Button
-              variant="destructive"
-              type="button"
-              onClick={confirmModeSwitch}
-            >
+            <Button variant="destructive" type="button" onClick={confirmModeSwitch}>
               Switch to {pendingMode ? MODES[pendingMode].label : switchLabel}
             </Button>
           </DialogFooter>
@@ -696,23 +616,14 @@ export const TimerWindow = () => {
           <DialogHeader>
             <DialogTitle>End this focus session now?</DialogTitle>
             <DialogDescription>
-              We&apos;ll save what you&apos;ve completed so far to your session
-              history, then move you to a break timer.
+              We&apos;ll save what you&apos;ve completed so far to your session history, then move you to a break timer.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button
-              variant="outline"
-              type="button"
-              onClick={cancelEndSessionEarly}
-            >
+            <Button variant="outline" type="button" onClick={cancelEndSessionEarly}>
               Keep focusing
             </Button>
-            <Button
-              variant="destructive"
-              type="button"
-              onClick={confirmEndSessionEarly}
-            >
+            <Button variant="destructive" type="button" onClick={confirmEndSessionEarly}>
               End session
             </Button>
           </DialogFooter>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -14,43 +14,35 @@ const buttonVariants = cva(
           "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost:
-          "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
         destructive:
           "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-primary underline-offset-4 hover:underline"
       },
       size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         icon: "size-8",
         "icon-xs":
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
+        "icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9"
+      }
     },
     defaultVariants: {
       variant: "default",
-      size: "default",
-    },
-  },
+      size: "default"
+    }
+  }
 );
 
 const Button = React.forwardRef<
   React.ElementRef<typeof ButtonPrimitive>,
   ButtonPrimitive.Props & VariantProps<typeof buttonVariants>
 >(({ className, variant = "default", size = "default", ...props }, ref) => (
-  <ButtonPrimitive
-    ref={ref}
-    data-slot="button"
-    className={cn(buttonVariants({ variant, size, className }))}
-    {...props}
-  />
+  <ButtonPrimitive ref={ref} data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />
 ));
 Button.displayName = "Button";
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -23,16 +23,13 @@ function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: DialogPrimitive.Backdrop.Props) {
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
-        className,
+        className
       )}
       {...props}
     />
@@ -54,7 +51,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
-          className,
+          className
         )}
         {...props}
       >
@@ -62,13 +59,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
+            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -80,13 +71,7 @@ function DialogContent({
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="dialog-header"
-      className={cn("gap-2 flex flex-col", className)}
-      {...props}
-    />
-  );
+  return <div data-slot="dialog-header" className={cn("gap-2 flex flex-col", className)} {...props} />;
 }
 
 function DialogFooter({
@@ -102,40 +87,29 @@ function DialogFooter({
       data-slot="dialog-footer"
       className={cn(
         "bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className,
+        className
       )}
       {...props}
     >
       {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
-        </DialogPrimitive.Close>
-      )}
+      {showCloseButton && <DialogPrimitive.Close render={<Button variant="outline" />}>Close</DialogPrimitive.Close>}
     </div>
   );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
-    <DialogPrimitive.Title
-      data-slot="dialog-title"
-      className={cn("text-base leading-none font-medium", className)}
-      {...props}
-    />
+    <DialogPrimitive.Title data-slot="dialog-title" className={cn("text-base leading-none font-medium", className)} {...props} />
   );
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: DialogPrimitive.Description.Props) {
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
         "text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3",
-        className,
+        className
       )}
       {...props}
     />
@@ -152,5 +126,5 @@ export {
   DialogOverlay,
   DialogPortal,
   DialogTitle,
-  DialogTrigger,
+  DialogTrigger
 };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     />

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -5,13 +5,7 @@ import { cn } from "@/lib/utils";
 import { CircleIcon } from "lucide-react";
 
 function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
-  return (
-    <RadioGroupPrimitive
-      data-slot="radio-group"
-      className={cn("grid gap-2 w-full", className)}
-      {...props}
-    />
-  );
+  return <RadioGroupPrimitive data-slot="radio-group" className={cn("grid gap-2 w-full", className)} {...props} />;
 }
 
 function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
@@ -20,7 +14,7 @@ function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
       data-slot="radio-group-item"
       className={cn(
         "border-input text-primary dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-3 aria-invalid:ring-3 group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     >

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,12 +1,6 @@
 import type { CSSProperties } from "react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
-import {
-  CircleCheckIcon,
-  InfoIcon,
-  TriangleAlertIcon,
-  OctagonXIcon,
-  Loader2Icon,
-} from "lucide-react";
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react";
 
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
@@ -19,20 +13,20 @@ const Toaster = ({ ...props }: ToasterProps) => {
         info: <InfoIcon className="size-4" />,
         warning: <TriangleAlertIcon className="size-4" />,
         error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />
       }}
       style={
         {
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
+          "--border-radius": "var(--radius)"
         } as CSSProperties
       }
       toastOptions={{
         classNames: {
-          toast: "cn-toast",
-        },
+          toast: "cn-toast"
+        }
       }}
       {...props}
     />

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -15,7 +15,7 @@ function Switch({
       data-size={size}
       className={cn(
         "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     >

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,47 +4,25 @@ import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
-      <table
-        data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
     </div>
   );
 }
 
 function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  );
+  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
 }
 
 function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
-  return (
-    <tbody
-      data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
-      {...props}
-    />
-  );
+  return <tbody data-slot="table-body" className={cn("[&_tr:last-child]:border-0", className)} {...props} />;
 }
 
 function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className,
-      )}
+      className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
       {...props}
     />
   );
@@ -54,10 +32,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   return (
     <tr
       data-slot="table-row"
-      className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className,
-      )}
+      className={cn("hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors", className)}
       {...props}
     />
   );
@@ -69,7 +44,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
       data-slot="table-head"
       className={cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -80,35 +55,14 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   return (
     <td
       data-slot="table-cell"
-      className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
-        className,
-      )}
+      className={cn("p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
       {...props}
     />
   );
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
-  return (
-    <caption
-      data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
-      {...props}
-    />
-  );
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+  return <caption data-slot="table-caption" className={cn("text-muted-foreground mt-4 text-sm", className)} {...props} />;
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-};
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/lib/ambient.ts
+++ b/src/lib/ambient.ts
@@ -4,17 +4,17 @@ export type AmbientSound = (typeof AMBIENT_SOUNDS)[number];
 export const DEFAULT_AMBIENT_VOLUMES: Record<AmbientSound, number> = {
   fire: 0,
   rain: 0,
-  forest: 0,
+  forest: 0
 };
 
 export const AMBIENT_SOUND_LABELS: Record<AmbientSound, string> = {
   fire: "Fire",
   rain: "Rain",
-  forest: "Forest",
+  forest: "Forest"
 };
 
 export const AMBIENT_SOUND_FILES: Record<AmbientSound, string> = {
   fire: "fire.mp3",
   rain: "rain.mp3",
-  forest: "forest.mp3",
+  forest: "forest.mp3"
 };

--- a/src/lib/hooks/timer-hooks.ts
+++ b/src/lib/hooks/timer-hooks.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getModeSeconds, type Mode } from "@/lib/pomodoro";
 import type { AppConfig } from "@/lib/hooks/app-hooks";
-import {
-  AMBIENT_SOUNDS,
-  AMBIENT_SOUND_FILES,
-  type AmbientSound,
-} from "@/lib/ambient";
+import { AMBIENT_SOUNDS, AMBIENT_SOUND_FILES, type AmbientSound } from "@/lib/ambient";
 
 type AudioEvent = "start" | "end";
 type AudioKey = `${Mode}_${AudioEvent}`;
@@ -14,13 +10,12 @@ const AUDIO_BASE_URL = `${import.meta.env.BASE_URL}audio/`;
 const REMINDER_INTERVAL_MS = 5 * 60 * 1000;
 
 const buildAudioMap = (language: AppConfig["audioLanguage"]) => {
-  const buildUrl = (audioMode: Mode, event: AudioEvent) =>
-    `${AUDIO_BASE_URL}${audioMode}_${event}_${language}.mp3`;
+  const buildUrl = (audioMode: Mode, event: AudioEvent) => `${AUDIO_BASE_URL}${audioMode}_${event}_${language}.mp3`;
   const map: Record<AudioKey, HTMLAudioElement> = {
     focus_start: new Audio(buildUrl("focus", "start")),
     focus_end: new Audio(buildUrl("focus", "end")),
     break_start: new Audio(buildUrl("break", "start")),
-    break_end: new Audio(buildUrl("break", "end")),
+    break_end: new Audio(buildUrl("break", "end"))
   };
   Object.values(map).forEach((audio) => {
     audio.preload = "auto";
@@ -55,28 +50,20 @@ const createAmbientAudioMap = () => {
   return map;
 };
 
-const clampAmbientVolume = (value: number) =>
-  Math.min(1, Math.max(0, value / 100));
+const clampAmbientVolume = (value: number) => Math.min(1, Math.max(0, value / 100));
 
 type PomodoroTimerOptions = {
   onVoiceAudioPlay?: (audio: HTMLAudioElement) => void;
   onFocusComplete?: (value: { startedAt: string; endedAt: string }) => void;
 };
 
-export const usePomodoroTimer = (
-  config: AppConfig,
-  options: PomodoroTimerOptions = {},
-) => {
+export const usePomodoroTimer = (config: AppConfig, options: PomodoroTimerOptions = {}) => {
   const [mode, setMode] = useState<Mode>("focus");
-  const [remaining, setRemaining] = useState(() =>
-    getModeSeconds("focus", config.focusMinutes, config.breakMinutes),
-  );
+  const [remaining, setRemaining] = useState(() => getModeSeconds("focus", config.focusMinutes, config.breakMinutes));
   const [isRunning, setIsRunning] = useState(false);
   const [pendingMode, setPendingMode] = useState<Mode | null>(null);
 
-  const onVoiceAudioPlayRef = useRef<PomodoroTimerOptions["onVoiceAudioPlay"]>(
-    options.onVoiceAudioPlay,
-  );
+  const onVoiceAudioPlayRef = useRef<PomodoroTimerOptions["onVoiceAudioPlay"]>(options.onVoiceAudioPlay);
 
   const audioMapRef = useRef(buildAudioMap(config.audioLanguage));
   const tickTockRef = useRef(createTickTockAudio());
@@ -88,7 +75,7 @@ export const usePomodoroTimer = (
   const focusStartedAtRef = useRef<Date | null>(null);
   const modeSecondsRef = useRef({
     focus: getModeSeconds("focus", config.focusMinutes, config.breakMinutes),
-    break: getModeSeconds("break", config.focusMinutes, config.breakMinutes),
+    break: getModeSeconds("break", config.focusMinutes, config.breakMinutes)
   });
 
   useEffect(() => {
@@ -131,18 +118,15 @@ export const usePomodoroTimer = (
     onVoiceAudioPlayRef.current = options.onVoiceAudioPlay;
   }, [options.onVoiceAudioPlay]);
 
-  const onFocusCompleteRef = useRef<PomodoroTimerOptions["onFocusComplete"]>(
-    options.onFocusComplete,
-  );
+  const onFocusCompleteRef = useRef<PomodoroTimerOptions["onFocusComplete"]>(options.onFocusComplete);
 
   useEffect(() => {
     onFocusCompleteRef.current = options.onFocusComplete;
   }, [options.onFocusComplete]);
 
   const getSecondsForMode = useCallback(
-    (nextMode: Mode) =>
-      getModeSeconds(nextMode, config.focusMinutes, config.breakMinutes),
-    [config.breakMinutes, config.focusMinutes],
+    (nextMode: Mode) => getModeSeconds(nextMode, config.focusMinutes, config.breakMinutes),
+    [config.breakMinutes, config.focusMinutes]
   );
 
   // Sync duration changes while idle and avoid surprising jumps.
@@ -155,7 +139,7 @@ export const usePomodoroTimer = (
   useEffect(() => {
     const next = {
       focus: getSecondsForMode("focus"),
-      break: getSecondsForMode("break"),
+      break: getSecondsForMode("break")
     };
     const prev = modeSecondsRef.current;
     modeSecondsRef.current = next;
@@ -230,7 +214,7 @@ export const usePomodoroTimer = (
             if (startedAt) {
               onFocusCompleteRef.current?.({
                 startedAt: startedAt.toISOString(),
-                endedAt: new Date().toISOString(),
+                endedAt: new Date().toISOString()
               });
             }
             focusStartedAtRef.current = null;
@@ -262,7 +246,7 @@ export const usePomodoroTimer = (
       setRemaining(getSecondsForMode(nextMode));
       focusStartedAtRef.current = null;
     },
-    [getSecondsForMode],
+    [getSecondsForMode]
   );
 
   const toggleRunning = useCallback(() => {
@@ -270,11 +254,7 @@ export const usePomodoroTimer = (
       const next = !prev;
       if (next) {
         playSound(mode, "start");
-        if (
-          mode === "focus" &&
-          remaining === getSecondsForMode("focus") &&
-          !focusStartedAtRef.current
-        ) {
+        if (mode === "focus" && remaining === getSecondsForMode("focus") && !focusStartedAtRef.current) {
           focusStartedAtRef.current = new Date();
         }
       }
@@ -311,7 +291,7 @@ export const usePomodoroTimer = (
     const endedAt = new Date();
     onFocusCompleteRef.current?.({
       startedAt: startedAt.toISOString(),
-      endedAt: endedAt.toISOString(),
+      endedAt: endedAt.toISOString()
     });
 
     focusStartedAtRef.current = null;
@@ -332,6 +312,6 @@ export const usePomodoroTimer = (
     requestModeSwitch,
     confirmModeSwitch,
     cancelModeSwitch,
-    endFocusSessionEarly,
+    endFocusSessionEarly
   };
 };

--- a/src/lib/pomodoro.ts
+++ b/src/lib/pomodoro.ts
@@ -12,7 +12,7 @@ export const DEFAULT_BREAK_MINUTES = 5;
 
 export const MODES: Record<Mode, ModeConfig> = {
   focus: { label: "Focus", seconds: DEFAULT_FOCUS_MINUTES * 60 },
-  break: { label: "Break", seconds: DEFAULT_BREAK_MINUTES * 60 },
+  break: { label: "Break", seconds: DEFAULT_BREAK_MINUTES * 60 }
 };
 
 export const clampTimerMinutes = (value: number) => {
@@ -21,11 +21,7 @@ export const clampTimerMinutes = (value: number) => {
   return Math.min(MAX_TIMER_MINUTES, Math.max(MIN_TIMER_MINUTES, rounded));
 };
 
-export const getModeSeconds = (
-  mode: Mode,
-  focusMinutes: number,
-  breakMinutes: number,
-) => {
+export const getModeSeconds = (mode: Mode, focusMinutes: number, breakMinutes: number) => {
   const minutes = mode === "focus" ? focusMinutes : breakMinutes;
   return clampTimerMinutes(minutes) * 60;
 };

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -27,6 +27,6 @@ if (root) {
     <React.StrictMode>
       <App />
       <Toaster />
-    </React.StrictMode>,
+    </React.StrictMode>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,9 +3,9 @@ import type { Config } from "tailwindcss";
 const config: Config = {
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
-    extend: {},
+    extend: {}
   },
-  plugins: [],
+  plugins: []
 };
 
 export default config;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -15,27 +15,27 @@ export default defineConfig({
         vite: {
           build: {
             rollupOptions: {
-              external: ["better-sqlite3", "get-windows"],
-            },
-          },
-        },
+              external: ["better-sqlite3", "get-windows"]
+            }
+          }
+        }
       },
       preload: {
-        input: "electron/preload.ts",
+        input: "electron/preload.ts"
       },
-      renderer: {},
+      renderer: {}
     }),
     nodePolyfills({
       include: ["url", "path", "fs", "stream", "events", "util"],
       globals: {
-        process: true,
-      },
-    }),
+        process: true
+      }
+    })
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
+      "@": path.resolve(__dirname, "./src")
+    }
   },
   base: "./",
   publicDir: "public",
@@ -46,9 +46,9 @@ export default defineConfig({
       output: {
         manualChunks: {
           pixi: ["pixi.js"],
-          live2d: ["pixi-live2d-display"],
-        },
-      },
-    },
-  },
+          live2d: ["pixi-live2d-display"]
+        }
+      }
+    }
+  }
 });


### PR DESCRIPTION
Closes #71 

## Summary
- configure `lefthook` `pre-commit` to run Prettier on staged files only and auto-stage fixes
- configure `lefthook` `pre-push` to run `npm run lint` and `npm run typecheck`
- configure `lefthook` `post-checkout` to run `npm install` when `package.json` exists
- update `npm run format` to run Prettier repo-wide with `--ignore-unknown .`
- add `.prettierignore` for generated/vendor directories (`dist`, `dist-electron`, `release`, `node_modules`, `public/live2d`)
- include one-time baseline formatting changes from running Prettier

## Notes
- no runtime feature behavior intended to change; this PR is tooling + formatting

## Testing
- `npm run lint`
- `npm run typecheck`
