### PR TITLE
feat: classify focus records by app then window title

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -455,6 +455,7 @@ const extractSessionRecords = (payload: unknown): { records: SessionRecord[]; re
               if (!segment || typeof segment !== "object") return null;
               const usageCandidate = segment as {
                 appName?: unknown;
+                windowTitle?: unknown;
                 startedAt?: unknown;
                 endedAt?: unknown;
               };
@@ -467,6 +468,10 @@ const extractSessionRecords = (payload: unknown): { records: SessionRecord[]; re
               }
               return {
                 appName: usageCandidate.appName,
+                windowTitle:
+                  typeof usageCandidate.windowTitle === "string" && usageCandidate.windowTitle.trim().length > 0
+                    ? usageCandidate.windowTitle
+                    : null,
                 startedAt: usageCandidate.startedAt,
                 endedAt: usageCandidate.endedAt
               } satisfies SessionAppUsage;

--- a/src/lib/session-types.ts
+++ b/src/lib/session-types.ts
@@ -1,5 +1,6 @@
 export type SessionAppUsage = {
   appName: string;
+  windowTitle?: string | null;
   startedAt: string;
   endedAt: string;
 };


### PR DESCRIPTION
# Summary
- persist optional window titles alongside app usage segments and keep schema in sync
- expand session detail UI to show per-app breakdowns with collapsible window-level totals and labels
- record window titles during focus tracking so data can power the new summary logic

# Testing
- Not run (not requested)

Closes #73 